### PR TITLE
Update preact to version 4.1.1 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "decko": "^1.1.3",
-    "preact": "^3.4.0",
+    "preact": "^4.1.1",
     "preact-compat": "^0.7.1",
     "preact-router": "^1.2.3",
     "proptypes": "^0.14.3",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[preact](https://www.npmjs.com/package/preact) just published its new version 4.1.1, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of preact – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 59 commits .
- [`cd904e9`](https://github.com/developit/preact/commit/cd904e9f7b383f963a8b2a308332d739d9cf252d) `4.1.1`
- [`d78b7ac`](https://github.com/developit/preact/commit/d78b7acf5f67421685e0df85c2f3b3de8428fbe8) `setState() callbacks should be called with the component as their context`
- [`b5ea6ae`](https://github.com/developit/preact/commit/b5ea6aeead04e5851d6318cf67bf453b7fab5521) `4.1.0`
- [`da414aa`](https://github.com/developit/preact/commit/da414aa1d5a55ec96f276616fe750e53c982183c) `White _ _ _ space`
- [`fb0dd2b`](https://github.com/developit/preact/commit/fb0dd2be58881021cf2f44a73d5134bd3f94fe2d) `Fix high order component refs linking to parent component when they should link to the child component/node.`
- [`7023623`](https://github.com/developit/preact/commit/7023623de28e51e18c37492919ca12c08be75d9e) `Fix child component refs not being invoked with`null`when the associated component is unmounted`
- [`bba4edc`](https://github.com/developit/preact/commit/bba4edcb693fd7c8a7d5d1fac5e51b477d56c601) `Merge pull request #66 from Craga89/patch-1`
- [`36ea3ee`](https://github.com/developit/preact/commit/36ea3eeded952908017d36e556e2e8ef538651ca) `[Bug] Fix multiple camelCase'd CSS properties`
- [`bbbeed0`](https://github.com/developit/preact/commit/bbbeed09c44a0802a77423f0ee536fbb361f873e) `4.0.1`
- [`530368e`](https://github.com/developit/preact/commit/530368e9ea14a8e958a52a453ac028680d0ebbf8) `Fix component refs`
- [`c0304dc`](https://github.com/developit/preact/commit/c0304dcb326316638c41c209b76409e1853a8230) `Add tests for`ref`:)`
- [`9f28a69`](https://github.com/developit/preact/commit/9f28a691bf1de9252b74d0b097628d41f7aad915) `Remove commented out code`
- [`206e39f`](https://github.com/developit/preact/commit/206e39f9ee2bc07412d34c6078993cfd983842cf) `We're only going to support function refs: https://twitter.com/_developit/status/702142526296293377`
- [`890fea0`](https://github.com/developit/preact/commit/890fea0e3293a44028a6ef15a26e9db12579e881) `Support function refs AND string refs (note: we're dropping string refs as they are legacy. will be moved to preact-compat)`
- [`b61a25b`](https://github.com/developit/preact/commit/b61a25b006b4590f8e000c79eb9a9a39ae84875c) `4.0.0`

There are 59 commits in total. See the [full diff](https://github.com/developit/preact/compare/ca687943a9404a897a0df3098b185e4042a2901d...cd904e9f7b383f963a8b2a308332d739d9cf252d).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
