### PR TITLE
Update preact-compat to version 1.4.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "decko": "^1.1.3",
     "preact": "^3.4.0",
-    "preact-compat": "^0.7.1",
+    "preact-compat": "^1.4.0",
     "preact-router": "^1.2.3",
     "proptypes": "^0.14.3",
     "snyk": "^1.10.0"


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[preact-compat](https://www.npmjs.com/package/preact-compat) just published its new version 1.4.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of preact-compat – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 35 commits .
- [`6dd49cd`](https://github.com/developit/preact-compat/commit/6dd49cdc8011efa5e7fec9bba0e12ec7ff76eb06) `1.4.0`
- [`8467cd8`](https://github.com/developit/preact-compat/commit/8467cd8b974ef58863a26c889091601b3fa419cf) `Update dependencies`
- [`745663c`](https://github.com/developit/preact-compat/commit/745663c29fbdd0f6805263aa64cadd1db516aa9c) `Add transparent support for SVG rendering, using preact-svg under the hood`
- [`e540577`](https://github.com/developit/preact-compat/commit/e540577ad636e86ea0b83bad79a42efc5b6e4554) `1.3.0`
- [`ce6282f`](https://github.com/developit/preact-compat/commit/ce6282f50c1f059882d0d250a947c074eaf0a211) `Emulate the unwrapped singular child behavior of React`
- [`2552507`](https://github.com/developit/preact-compat/commit/2552507d83643203abd94eab1e331e71ef45df51) `1.2.1`
- [`b851e69`](https://github.com/developit/preact-compat/commit/b851e6996d2b2d5a0c15862a66534c008da92877) `Fix incorrect creation of element factories`
- [`36cf3a3`](https://github.com/developit/preact-compat/commit/36cf3a3636f65592a8d51655f9976fa913329ce7) `1.2.0`
- [`c961616`](https://github.com/developit/preact-compat/commit/c961616389594066e939969ee9cd9b25ecaa25b9) `Add support for`react-dom/server`, which is basically just two names for`preact-render-to-string`.`
- [`1ebad70`](https://github.com/developit/preact-compat/commit/1ebad705e72b82ae4f8026ba0d82306e4e3c50e8) `- Add support for the last 3 methods from`ReactDOM`:`createFactory()`,`cloneElement()`, and`isValidElement()``
- [`2ef7996`](https://github.com/developit/preact-compat/commit/2ef7996a8833f71a027e3df6c392868873589342) `1.1.0`
- [`b523a72`](https://github.com/developit/preact-compat/commit/b523a72ff7a06819bb78107e7e75b23587605288) `Require preact 4.1, which includes ref fixes`
- [`e3d9434`](https://github.com/developit/preact-compat/commit/e3d94343d3b5232db93580995a555cf46a74f655) `Uncomment child component ref assertion since Preact`4.1.0`fixed the breaking issue.`
- [`96805bd`](https://github.com/developit/preact-compat/commit/96805bd451ef18bcb105ff992ed41e2ff74e1f6b) `Don't use JSX internally, drop unnecessary function ref.`
- [`117d49d`](https://github.com/developit/preact-compat/commit/117d49dbfb3101d77575d4ff07bb4d8c61c279d6) `Sneakily patch preact's VNode type so it validates correctly in`propTypes.node``

There are 35 commits in total. See the [full diff](https://github.com/developit/preact-compat/compare/da32323a19df5f820d601d24c13559b59e1790f9...6dd49cdc8011efa5e7fec9bba0e12ec7ff76eb06).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
