### PR TITLE
Update preact-compat to version 1.6.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "decko": "^1.1.3",
     "preact": "^3.4.0",
-    "preact-compat": "^0.7.1",
+    "preact-compat": "^1.6.0",
     "preact-router": "^1.2.3",
     "proptypes": "^0.14.3",
     "snyk": "^1.10.0"


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[preact-compat](https://www.npmjs.com/package/preact-compat) just published its new version 1.6.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of preact-compat – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 43 commits .
- [`52d2612`](https://github.com/developit/preact-compat/commit/52d2612bf734a11d1215f0b5ce6f6b98d773d4af) `1.6.0`
- [`1079b56`](https://github.com/developit/preact-compat/commit/1079b56e66f925e2662c65f4027f6eb8581b0e59) `Add support for jsnext:main`
- [`26a71f1`](https://github.com/developit/preact-compat/commit/26a71f14e9ed01c6543624a94655c27f6ae088b2) `Make process.env.NODE_ENV===production detection statically analyzable (for tree shaking, etc)`
- [`9a90de6`](https://github.com/developit/preact-compat/commit/9a90de64b1619026af4b94249001f57b399bce94) `1.5.0`
- [`a53f193`](https://github.com/developit/preact-compat/commit/a53f1936446208818e3d1783b45e641ea4b2ebff) `A slightly less abrasive fix for children.length.`
- [`b0c64d9`](https://github.com/developit/preact-compat/commit/b0c64d9a357f245253450ee6eba38895302e9022) `Restore sane and consistent always-array semantics for`props.children`after validation (this might be iffy, but it at least doesn't break react-toolbox)`
- [`9235834`](https://github.com/developit/preact-compat/commit/9235834e23590d2ae1b28ad64832761bb0321b6a) `Fix edge case where unmounting a parent component could result in a child component invoking a null ref.`
- [`5f068b4`](https://github.com/developit/preact-compat/commit/5f068b4c1cc8fb1d84dbd740c8765f71be65253b) `Alias`VNode`'s`attributes`and`nodeName`as`props`and`type`(respectively) to make libraries that mess with rendered JSX happy.`
- [`6dd49cd`](https://github.com/developit/preact-compat/commit/6dd49cdc8011efa5e7fec9bba0e12ec7ff76eb06) `1.4.0`
- [`8467cd8`](https://github.com/developit/preact-compat/commit/8467cd8b974ef58863a26c889091601b3fa419cf) `Update dependencies`
- [`745663c`](https://github.com/developit/preact-compat/commit/745663c29fbdd0f6805263aa64cadd1db516aa9c) `Add transparent support for SVG rendering, using preact-svg under the hood`
- [`e540577`](https://github.com/developit/preact-compat/commit/e540577ad636e86ea0b83bad79a42efc5b6e4554) `1.3.0`
- [`ce6282f`](https://github.com/developit/preact-compat/commit/ce6282f50c1f059882d0d250a947c074eaf0a211) `Emulate the unwrapped singular child behavior of React`
- [`2552507`](https://github.com/developit/preact-compat/commit/2552507d83643203abd94eab1e331e71ef45df51) `1.2.1`
- [`b851e69`](https://github.com/developit/preact-compat/commit/b851e6996d2b2d5a0c15862a66534c008da92877) `Fix incorrect creation of element factories`

There are 43 commits in total. See the [full diff](https://github.com/developit/preact-compat/compare/da32323a19df5f820d601d24c13559b59e1790f9...52d2612bf734a11d1215f0b5ce6f6b98d773d4af).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
